### PR TITLE
feat(job): fetch and display active job listings with relative time formatting

### DIFF
--- a/app/(mainLayout)/page.tsx
+++ b/app/(mainLayout)/page.tsx
@@ -1,13 +1,14 @@
+
 import JobFilter from "@/components/general/JobFilters";
-import { Card } from "@/components/ui/card";
+import JobListings from "@/components/general/JobListings";
 
 export default function Home() {
   return (
     <div className="grid grid-cols-3 gap-8">
       <JobFilter />
-      <Card className="col-span-2">
-
-      </Card>
+      <div className="col-span-2 flex flex-col gap-6">
+        <JobListings />
+      </div>
     </div>
   );
 }

--- a/app/utils/formatRelativeTime.tsx
+++ b/app/utils/formatRelativeTime.tsx
@@ -1,0 +1,23 @@
+const formatRelativeTime = (date: Date) => {
+  const now = new Date();
+
+  const diffInDays = Math.floor(
+    (now.getTime() - new Date(date).getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  if (diffInDays === 0) {
+    return "Posted Today";
+  } else if (diffInDays === 1) {
+    return "Posted Yesterday";
+  } else if (diffInDays < 7) {
+    return `Posted ${diffInDays} Days Ago`;
+  } else if (diffInDays < 31) {
+    return `Posted ${Math.floor(diffInDays / 7)} Weeks Ago`;
+  } else if (diffInDays < 365) {
+    return `Posted ${Math.floor(diffInDays / 30)} Months Ago`;
+  } else {
+    return `Posted ${Math.floor(diffInDays / 365)} Years Ago`;
+  }
+};
+
+export default formatRelativeTime;

--- a/components/general/EmptyState.tsx
+++ b/components/general/EmptyState.tsx
@@ -1,0 +1,30 @@
+import { Ban, PlusCircle } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "../ui/button";
+
+interface iAppProps {
+  title: string;
+  description: string;
+  buttonText: string;
+  href: string;
+}
+
+const EmptyState = ({ title, description, buttonText, href }: iAppProps) => {
+  return (
+    <div className="flex flex-col flex-1 h-full justify-center items-center rounded-md border border-dashed p-8">
+      <div className="flex size-20 items-center justify-center rounded-full bg-primary/10">
+        <Ban className="size-10 text-primary" />
+      </div>
+      <h2 className="mt-6 text-xl font-semibold">{title}</h2>
+      <p className="mt-2 mb-2 text-center text-sm leading-tight text-muted-foreground max-w-sm text-balance">
+        {description}
+      </p>
+
+      <Link href={href} className={buttonVariants()}>
+        <PlusCircle /> {buttonText}
+      </Link>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/components/general/JobCard.tsx
+++ b/components/general/JobCard.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { Card, CardHeader } from "../ui/card";
+import Image from "next/image";
+import { Badge } from "../ui/badge";
+import { formatCurrency } from "@/app/utils/formatCurrency";
+import { MapPin } from "lucide-react";
+import formatRelativeTime from "@/app/utils/formatRelativeTime";
+
+interface iAppProps {
+  job: {
+    id: string;
+    createdAt: Date;
+    Company: {
+      about: string;
+      name: string;
+      location: string;
+      logo: string;
+    };
+    jobTitle: string;
+    employmentType: string;
+    location: string;
+    salaryFrom: number;
+    salaryTo: number;
+  };
+}
+
+const JobCard = ({ job }: iAppProps) => {
+  return (
+    <Link href={`/job`}>
+      <Card className="hover:shadow-lg transition-all duration-300 hover:border-primary">
+        <CardHeader>
+          <div className="flex flex-col md:flex-row gap-4 items-center">
+            <div>
+              <Image
+                src={job.Company.logo}
+                alt={job.Company.name}
+                width={64}
+                height={64}
+                className="size-16 rounded-lg"
+              />
+            </div>
+            <div>
+              <h1 className="text-xl md:text-2xl font-bold">{job.jobTitle}</h1>
+              <div className="flex flex-wrap gap-2">
+                <p className="text-sm text-muted-foreground">
+                  {job.Company.name}
+                </p>
+                <span className="hidden md:inline text-muted-foreground">
+                  *
+                </span>
+                <Badge className="rounded-full" variant="secondary">
+                  {job.employmentType}
+                </Badge>
+                <span className="hidden md:inline text-muted-foreground">
+                  *
+                </span>
+                <Badge className="rounded-full">{job.location}</Badge>
+                <span className="hidden md:inline text-muted-foreground">
+                  *
+                </span>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  {formatCurrency(job.salaryFrom)} -{" "}
+                  {formatCurrency(job.salaryTo)}
+                </p>
+              </div>
+            </div>
+            <div className="md:ml-auto text-right">
+              <div className="flex items-center gap-2 justify-end">
+                <MapPin className="size-4" />
+                <h1>{job.location}</h1>
+              </div>
+              <p className="text-sm text-muted-foreground md:text-right">
+                {formatRelativeTime(job.createdAt)}
+              </p>
+            </div>
+          </div>
+          <p className="text-base text-muted-foreground line-clamp-2 !mt-5">
+            {job.Company.about}
+          </p>
+        </CardHeader>
+      </Card>
+    </Link>
+  );
+};
+
+export default JobCard;

--- a/components/general/JobFilters.tsx
+++ b/components/general/JobFilters.tsx
@@ -11,7 +11,7 @@ const jobTypes = ["full-time", "part-time", "remote", "freelance", "internship",
 
 export default function JobFilter() {
     return (
-        <Card className="col-span-1">
+        <Card className="col-span-1 h-fit">
             <CardHeader className="flex flex-row justify-between items-center">
                 <CardTitle className="text-2xl font-semibold">Filters</CardTitle>
                 <Button variant="destructive" size="sm" className="h-8">

--- a/components/general/JobListings.tsx
+++ b/components/general/JobListings.tsx
@@ -1,0 +1,57 @@
+import { prisma } from "@/app/utils/db";
+import EmptyState from "./EmptyState";
+import JobCard from "./JobCard";
+
+async function getData() {
+  const data = await prisma.jobPost.findMany({
+    where: {
+      status: "ACTIVE",
+    },
+    select: {
+      jobTitle: true,
+      id: true,
+      salaryFrom: true,
+      salaryTo: true,
+      employmentType: true,
+      location: true,
+      createdAt: true,
+      Company: {
+        select: {
+          name: true,
+          logo: true,
+          location: true,
+          about: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return data;
+}
+
+const JobListings = async () => {
+  const data = await getData();
+  return (
+    <>
+      {data.length > 0 ? (
+        <div className="flex flex-col gap-6">
+          {data.map((job) => (
+            <JobCard key={job.id} job={job} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          title="No Jobs Found"
+          description="Try changing your filters or searching for a job"
+          buttonText="Clear all filters"
+          href="/"
+        />
+      )}
+    </>
+  );
+};
+
+export default JobListings;


### PR DESCRIPTION
# 📄 **Penjelasan Kode**

## 1. **JobListing.tsx**
- Fungsi `getData()`
  - Fetch semua data `JobPost` dari database pakai Prisma.
  - Cuman ambil job yang statusnya `"ACTIVE"`.
  - Select beberapa field aja (efisien, gak semua kolom diambil).
  - Urutkan berdasarkan `createdAt` **descending** (yang terbaru muncul duluan).

- Komponen `JobListings`
  - **Async component** yang langsung manggil `getData()` saat render.
  - Kalau **data ada**, render semua `JobCard`.
  - Kalau **data kosong**, munculin `EmptyState` dengan tombol untuk reset.

---

## 2. **JobCard.tsx**
![image](https://github.com/user-attachments/assets/4844b5ff-4f75-4534-8c35-ab6792d28570)
- Komponen `JobCard`
  - Terima props `job` yang isinya detail job.
  - Bungkus semua di dalam `Link` menuju `/job` (nanti bisa diupgrade dynamic route `/job/[id]`).
  - Menampilkan:
    - Logo perusahaan.
    - Nama job title.
    - Nama company, employment type (badge), lokasi (badge).
    - Salary range pakai `formatCurrency`.
    - Lokasi + waktu posting pakai `formatRelativeTime`.
    - About dari perusahaan.
  - Styling rapi pake Tailwind, hover effect juga udah ada (UX ++).

---

## 3. **formatRelativeTime.tsx**
- Fungsi `formatRelativeTime(date: Date)`
  - Hitung **selisih hari** antara `date` dan `now`.
  - Logic kondisi:
    - 0 hari ➔ "Posted Today"
    - 1 hari ➔ "Posted Yesterday"
    - <7 hari ➔ "Posted X Days Ago"
    - <31 hari ➔ "Posted X Weeks Ago"
    - <365 hari ➔ "Posted X Months Ago"
    - >365 hari ➔ "Posted X Years Ago"
  - User-friendly time label, mirip UX di LinkedIn, Jobstreet, dsb.

---